### PR TITLE
Resolve #37: Logger Handler

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,1 +1,0 @@
-{"image":"python:2.7"}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,1 @@
+{"image":"python:2.7"}

--- a/sqlite_dissect/entrypoint.py
+++ b/sqlite_dissect/entrypoint.py
@@ -1,12 +1,6 @@
 import uuid
 import warnings
-from logging import CRITICAL
-from logging import DEBUG
-from logging import ERROR
-from logging import INFO
-from logging import WARNING
-from logging import basicConfig
-from logging import getLogger
+from logging import CRITICAL, ERROR, WARNING, INFO, DEBUG, basicConfig, getLogger, StreamHandler, FileHandler
 from os import path
 from os.path import basename
 from os.path import join
@@ -66,6 +60,7 @@ def main(arguments, sqlite_file_path, export_sub_paths=False):
         raise SqliteError("Error in setting up logging: no log level determined.")
 
     # Get the logging level
+    logger = getLogger(LOGGER_NAME)
     logging_level_arg = arguments.log_level
     logging_level = logging_level_arg
     if logging_level_arg != "off":
@@ -82,13 +77,17 @@ def main(arguments, sqlite_file_path, export_sub_paths=False):
         else:
             raise SqliteError("Invalid option for logging: {}.".format(logging_level_arg))
 
-        # Setup logging
-        logging_format = '%(levelname)s %(asctime)s [%(pathname)s] %(funcName)s at line %(lineno)d: %(message)s'
-        logging_data_format = '%d %b %Y %H:%M:%S'
-        basicConfig(level=logging_level, format=logging_format, datefmt=logging_data_format,
-                    filename=arguments.log_file)
+    # Setup logging
+    if arguments.log_file:
+        handler = FileHandler(arguments.log_file)
+    else:
+        handler = StreamHandler()
 
-    logger = getLogger(LOGGER_NAME)
+    basicConfig(level=logging_level,
+                format='%(levelname)s %(asctime)s [%(pathname)s] %(funcName)s at line %(lineno)d: %(message)s',
+                datefmt='%d %b %Y %H:%M:%S',
+                handler=handler)
+
     logger.debug("Setup logging using the log level: {}.".format(logging_level))
     logger.info("Using options: {}".format(arguments))
 

--- a/sqlite_dissect/entrypoint.py
+++ b/sqlite_dissect/entrypoint.py
@@ -76,17 +76,14 @@ def main(arguments, sqlite_file_path, export_sub_paths=False):
             logging_level = DEBUG
         else:
             raise SqliteError("Invalid option for logging: {}.".format(logging_level_arg))
+    else:
+        logging_level = None
 
     # Setup logging
-    if arguments.log_file:
-        handler = FileHandler(arguments.log_file)
-    else:
-        handler = StreamHandler()
-
     basicConfig(level=logging_level,
                 format='%(levelname)s %(asctime)s [%(pathname)s] %(funcName)s at line %(lineno)d: %(message)s',
                 datefmt='%d %b %Y %H:%M:%S',
-                handler=handler)
+                filename=arguments.log_file if arguments.log_file else None)
 
     logger.debug("Setup logging using the log level: {}.".format(logging_level))
     logger.info("Using options: {}".format(arguments))

--- a/sqlite_dissect/utilities.py
+++ b/sqlite_dissect/utilities.py
@@ -465,7 +465,7 @@ def parse_args(args=None):
                         default=None,
                         metavar="LOG_FILE",
                         env_var="SQLD_LOG_FILE",
-                        help="log file to write to. Default is to write to console, ignored if log level set to off "
+                        help="log file to write to; default is to write to console, ignored if log level set to off "
                              "(appends if file already exists)")
 
     parser.add_argument("--warnings",

--- a/sqlite_dissect/utilities.py
+++ b/sqlite_dissect/utilities.py
@@ -465,7 +465,7 @@ def parse_args(args=None):
                         default=None,
                         metavar="LOG_FILE",
                         env_var="SQLD_LOG_FILE",
-                        help="log file to write too, default is to write to console, ignored if log level set to off "
+                        help="log file to write to. Default is to write to console, ignored if log level set to off "
                              "(appends if file already exists)")
 
     parser.add_argument("--warnings",


### PR DESCRIPTION
Addresses https://github.com/dod-cyber-crime-center/sqlite-dissect/issues/37 by adding logging handlers even when the `log_level` is set to `"off"` and properly sets the `basicConfig.level` to `None` if disabled.

Steps to reproduce the initial issue with the existing repository:
```shell
# Setup SQLite Dissect
python setup.py install

# Delete the journal file so it doesn't conflict with the WAL file
rm sqlite_dissect/tests/test_files/chinook.sqlite-journal

# Create a temporary output directory
mkdir output

# Run SQLite Dissect
sqlite_dissect sqlite_dissect/tests/test_files/chinook.sqlite -e sqlite -d output --carve
```