### PR TITLE
CASE 1.3.0 Support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on: [ push ]
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         # Once we move to Python 3.x, this can be tested against multiple Python versions. eg. [3.6, 3.7, 3.8, 3.9]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
 
       # Run the CASE validation job to confirm the output is valid
       - name: CASE Export Validation
-        uses: kchason/case-validation-action@v2.9
+        uses: kchason/case-validation-action@v2.9.0
         with:
           case-path: ./output/case.json
           case-version: "case-1.3.0"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on: [ push ]
 jobs:
   build:
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         # Once we move to Python 3.x, this can be tested against multiple Python versions. eg. [3.6, 3.7, 3.8, 3.9]
@@ -19,7 +19,7 @@ jobs:
       # Setup the Python environment (currently Python 2.7). This will need to be
       # updated when the project is upgraded to Python 3.x
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       # Setup the Python environment (currently Python 2.7). This will need to be
       # updated when the project is upgraded to Python 3.x
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,12 +14,12 @@ jobs:
     steps:
       # Get the code from the repository to be packaged
       - name: Get Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # Setup the Python environment (currently Python 2.7). This will need to be
       # updated when the project is upgraded to Python 3.x
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -48,14 +48,14 @@ jobs:
 
       # Run the CASE validation job to confirm the output is valid
       - name: CASE Export Validation
-        uses: kchason/case-validation-action@v2.5
+        uses: kchason/case-validation-action@v2.9
         with:
           case-path: ./output/case.json
-          case-version: "case-1.1.0"
+          case-version: "case-1.3.0"
 
       # Upload the PyTest HTML coverage report for review
       - name: Upload PyTest Coverage
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: code-coverage-report
           path: htmlcov
@@ -69,7 +69,7 @@ jobs:
 
       # Upload the HTML documentation for distribution
       - name: Upload HTML Docs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: html-docs
           path: ./docs/build/


### PR DESCRIPTION
- Bumps the validation for CASE 1.3.0 for the output validation
- Increases GitHub actions to their latest major versions to avoid deprecation issues